### PR TITLE
Gnome Shell 49 version support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,10 +6,12 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
-  "settings-schema":"org.gnome.shell.extensions.gamemodeshellextension",
+  "settings-schema": "org.gnome.shell.extensions.gamemodeshellextension",
   "url": "https://github.com/trsnaqe/gamemode-shell-extension",
   "donations": {
     "buymeacoffee": "trsnaqe"
-}}
+  }
+}


### PR DESCRIPTION
I've tested the extension in Arch Linux + Gnome Shell 49 version and all worked very fine. No errors have been founded when playing steam games with gamemode.